### PR TITLE
Fix: Configure Vercel to correctly serve SPA frontend

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -11,4 +11,7 @@ export default defineConfig({
       '@shared': path.resolve(__dirname, '../shared'),
     },
   },
+  build: {
+    outDir: '../dist',
+  },
 })

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build client && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --define:process.env.NODE_ENV='\"production\"'",
-    "start": "NODE_ENV=production node dist/index.js",
+    "build": "vite build client && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/server/index.js --define:process.env.NODE_ENV='\"production\"'",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,11 @@
 {
   "buildCommand": "npm run build",
   "framework": "vite",
-  "outputDirectory": "dist"
-
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
- Modified `package.json` to output the esbuild server bundle to `dist/server/index.js` instead of `dist/index.js` to avoid conflicts with the static frontend's `index.html`.
- Updated `client/vite.config.ts` to set `build.outDir` to `../dist`, ensuring client assets are built directly into the root `dist` folder that Vercel uses.
- Added SPA rewrite rule `{"source": "/(.*)", "destination": "/index.html"}` to `vercel.json` to ensure all non-API paths serve the `index.html` of the single-page application.

These changes aim to resolve the issue where Vercel was serving raw JavaScript instead of the built frontend application.