### PR TITLE
Fix: Correct mismatched JSX tags in NewsletterSection

### DIFF
--- a/client/src/components/newsletter-section.tsx
+++ b/client/src/components/newsletter-section.tsx
@@ -22,7 +22,8 @@ export default function NewsletterSection() {
                 Subscribe
               </Button>
             </div>{/* Remove the misplaced closing tags and fix the div nesting */}
-      </div>
+        </div>
+      </div> {/* This closes the div with class "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8" */}
     </section>
   );
 }


### PR DESCRIPTION
The Vercel build failed due to improperly nested JSX tags in the `client/src/components/newsletter-section.tsx` component.

This commit fixes the issue by ensuring all `div` elements are correctly closed in the proper order, specifically by adding a missing closing `</div>` tag for the `max-w-7xl` container.